### PR TITLE
ESPHome v1.13 Update

### DIFF
--- a/copychan.h
+++ b/copychan.h
@@ -1,5 +1,3 @@
-using namespace esphomelib::output;
-
 class CopyOutput : public FloatOutput {
  public:
   FloatOutput *channel_a;


### PR DESCRIPTION
`esphomelib` namespace was deprecatd in 1.12 and removed in 1.13

So it would now be `using namespace esphome::output;`

But, ESPHome v1.13 includes those namespaces automatically, so the line can be removed.