### PR TITLE
Update lohas_cct.yaml

### DIFF
--- a/lohas_cct.yaml
+++ b/lohas_cct.yaml
@@ -59,6 +59,8 @@ output:
 light:
   - platform: rgbww
     name: ${display_name}
+    constant_brightness: true
+    color_interlock: true
     red: output_red
     green: output_green
     blue: output_blue


### PR DESCRIPTION
Added constant_brightness and color_interlock flags to prevent bulbs from overheating. They can't handle both sets of LEDs being on at full brightness or both white and color LEDs at the same time. This drops the average temperature of the bulbs in open air by ~40F from 187F to 147F and more than 50F from ~208F to ~156F in enclosed fixtures.